### PR TITLE
skip empty transcript

### DIFF
--- a/bot/utils.py
+++ b/bot/utils.py
@@ -52,6 +52,12 @@ def load_pdf(f: str) -> str:
     return "\n".join([doc.page_content for doc in docs])
 
 
+def load_youtube_transcript(video_id: str) -> str:
+    loader = YoutubeLoader(video_id, add_video_info=True, language=["en", "zh", "ja"])
+    docs = loader.load()
+    return "\n".join([doc.page_content for doc in docs])
+
+
 # parse by regex
 def parse_youtube_video_id(url: str) -> str:
     # https://www.youtube.com/watch?v=VIDEO_ID
@@ -70,9 +76,9 @@ def parse_youtube_video_id(url: str) -> str:
 def load_url(url: str) -> str:
     video_id = parse_youtube_video_id(url)
     if video_id:
-        loader = YoutubeLoader(video_id, add_video_info=True, language=["en", "zh", "ja"])
-        docs = loader.load()
-        return "\n".join([doc.page_content for doc in docs])
+        transcript = load_youtube_transcript(video_id)
+        if transcript:
+            return transcript
 
     f = download(url)
 


### PR DESCRIPTION
This pull request introduces a new function for loading YouTube transcripts and refactors existing code to utilize this new function. The main changes involve adding the `load_youtube_transcript` function and updating the `load_url` function to use it.

### New Functionality:
* [`bot/utils.py`](diffhunk://#diff-dd45f3df183d56681fe535b88682614d873aa4583f66868e34736c251d3c28a9R55-R60): Added the `load_youtube_transcript` function to handle loading YouTube transcripts with additional video information and support for multiple languages.

### Code Refactoring:
* [`bot/utils.py`](diffhunk://#diff-dd45f3df183d56681fe535b88682614d873aa4583f66868e34736c251d3c28a9L73-R81): Updated the `load_url` function to use the newly added `load_youtube_transcript` function, simplifying the code and ensuring consistency.