### PR TITLE
fix RuntimeWarning

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -69,7 +69,8 @@ class Bot:
         text = load_url(url)
         if not text:
             logger.info("Failed to load URL")
-            return update.message.reply_text("Failed to load URL")
+            await update.message.reply_text("Failed to load URL")
+            return
 
         summarized = summarize()
         logger.info("Replying to chat ID: {} with: {}", update.message.chat_id, summarized)


### PR DESCRIPTION
This pull request includes a small change to the `bot/bot.py` file. The change updates the `summarize_url` method to use the `await` keyword when calling `update.message.reply_text`.

* [`bot/bot.py`](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L72-R73): Updated `summarize_url` method to use `await` when calling `update.message.reply_text` to ensure proper asynchronous behavior.