### PR TITLE
use filter and show chat id

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -7,6 +7,7 @@ from telegram import Update
 from telegram.ext import Application
 from telegram.ext import CommandHandler
 from telegram.ext import ContextTypes
+from telegram.ext import filters
 
 from .summary import summarize
 from .translate import translate
@@ -24,8 +25,9 @@ class Bot:
 
         # Create the application and add the command handler
         self.app = Application.builder().token(token).build()
-        self.app.add_handler(CommandHandler("sum", self.summarize_url))
-        self.app.add_handler(CommandHandler("jp", self.translate_jp))
+        self.app.add_handler(CommandHandler("sum", self.summarize_url, filters=filters.Chat(self.whitelist)))
+        self.app.add_handler(CommandHandler("jp", self.translate_jp, filters=filters.Chat(self.whitelist)))
+        self.app.add_handler(CommandHandler("chat_id", self.show_chat_id))
         self.app.run_polling(allowed_updates=Update.ALL_TYPES)
 
     @classmethod
@@ -43,6 +45,16 @@ class Bot:
 
         return cls(token=token, whitelist=[int(chat_id) for chat_id in whitelist.replace(" ", "").split(",")])
 
+    # show chat_id
+    async def show_chat_id(self, update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+        """
+        Show the chat ID of the current chat.
+        """
+        if not update.message:
+            return
+
+        await update.message.reply_text(f"Chat ID: {update.message.chat_id}")
+
     async def summarize_url(self, update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         """
         Summarize the URL found in the message text and reply with the summary.
@@ -51,10 +63,6 @@ class Bot:
             return
 
         logger.info("Received message: '{}' from chat ID: {}", update.message.text, update.message.chat_id)
-
-        if update.message.chat_id not in self.whitelist:
-            logger.info("Chat ID {} not in whitelist", update.message.chat_id)
-            return
 
         raw_text = update.message.text
         if update.message.reply_to_message and update.message.reply_to_message.text:
@@ -84,10 +92,6 @@ class Bot:
             return
 
         logger.info("Received message: '{}' from chat ID: {}", update.message.text, update.message.chat_id)
-
-        if update.message.chat_id not in self.whitelist:
-            logger.info("Chat ID {} not in whitelist", update.message.chat_id)
-            return
 
         raw_text = update.message.text
         if update.message.reply_to_message and update.message.reply_to_message.text:


### PR DESCRIPTION
This pull request includes several updates to the `bot/bot.py` file, primarily focusing on improving the command handling and adding a new command to show the chat ID. The most important changes include adding filters to command handlers, introducing a new command to display the chat ID, and removing redundant whitelist checks.

### Command Handling Improvements:

* Added `filters.Chat` to the `summarize_url` and `translate_jp` command handlers to filter messages based on the whitelist. (`bot/bot.py`, [bot/bot.pyL27-R30](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L27-R30))

### New Command:

* Introduced a new `show_chat_id` command to display the chat ID of the current chat. (`bot/bot.py`, [bot/bot.pyR48-R57](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7R48-R57))

### Code Cleanup:

* Removed redundant whitelist checks from the `summarize_url` and `translate_jp` methods, as they are now handled by the filters. (`bot/bot.py`, [[1]](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L55-L58) [[2]](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L88-L91)

### Dependency Management:

* Added import for `filters` from `telegram.ext` to support the new filter functionality. (`bot/bot.py`, [bot/bot.pyR10](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7R10))