### PR TITLE
Refactor get_full_message_text function to extract the full text

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -15,6 +15,19 @@ from .utils import load_document
 from .utils import parse_url
 
 
+def get_full_message_text(update: Update) -> str:
+    """
+    Extract the full text of the message and the reply-to message, if any.
+    """
+    message = update.message
+    reply_message = message.reply_to_message
+
+    message_text = message.text if message.text else ""
+    reply_text = reply_message.text if reply_message and reply_message.text else ""
+
+    return f"{message_text}\n{reply_text}" if reply_text else message_text
+
+
 class Bot:
     def __init__(self, token: str, whitelist: list[int]) -> None:
         """
@@ -65,9 +78,7 @@ class Bot:
         if not update.message or not update.message.text:
             return
 
-        raw_text = update.message.text
-        if update.message.reply_to_message and update.message.reply_to_message.text:
-            raw_text += "\n" + update.message.reply_to_message.text
+        raw_text = get_full_message_text(update)
 
         url = parse_url(raw_text)
         if not url:
@@ -94,9 +105,7 @@ class Bot:
         if not update.message or not update.message.text:
             return
 
-        raw_text = update.message.text
-        if update.message.reply_to_message and update.message.reply_to_message.text:
-            raw_text += "\n" + update.message.reply_to_message.text
+        raw_text = get_full_message_text(update)
 
         translated = translate(raw_text, lang="日文")
         logger.info("Replying to chat ID: {} with: {}", update.message.chat_id, translated)

--- a/test_download.py
+++ b/test_download.py
@@ -1,0 +1,34 @@
+import os
+import pickle
+
+import httpx
+
+from bot.utils import download
+
+# def save_cookies(client: httpx.Client):
+#     with open("cookies.pk", "wb") as f:
+#         pickle.dump(client.cookies.jar._cookies, f)
+
+
+# def load_cookies():
+#     if not os.path.isfile("cookies.pk"):
+#         return None
+#     cookies = httpx.Cookies()
+#     with open("cookies.pk", "rb") as f:
+#         jar_cookies = pickle.load(f)
+#     for domain, pc in jar_cookies.items():
+#         for path, c in pc.items():
+#             for k, v in c.items():
+#                 cookies.set(k, v.value, domain=domain, path=path)
+#     return cookies
+
+
+def main() -> None:
+    # url = "https://www.nature.com/articles/s41586-024-07930-y"
+    url = "https://www.nature.com/articles/s41586-024-07930-y.pdf"
+    path = download(url)
+    print(path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a new utility function to extract the full text of a message and its reply, and refactors existing methods to use this new function. Additionally, it includes a new test script for downloading files. 

### New Utility Function:

* [`bot/bot.py`](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7R18-R30): Added `get_full_message_text` function to extract the full text of a message and its reply-to message, if any.

### Refactoring:

* [`bot/bot.py`](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L68-R81): Updated `summarize_url` and `translate_jp` methods to use the new `get_full_message_text` function for extracting message text. [[1]](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L68-R81) [[2]](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L97-R108)

### New Test Script:

* [`test_download.py`](diffhunk://#diff-a3bc27ef77cca6ba1b2163cb12b79f25699fce0b2f13305d0ca7f67893fc9a1dR1-R34): Added a new test script to download a file from a provided URL and print the path.…he message and the reply-to message, if any