### PR TITLE
refactor bot

### DIFF
--- a/bot/cli.py
+++ b/bot/cli.py
@@ -1,11 +1,11 @@
 from dotenv import find_dotenv
 from dotenv import load_dotenv
 
-from .bot import Bot
+from .bot import run_bot
 from .utils import set_sqlite_llm_cache
 
 
 def main():
     load_dotenv(find_dotenv(raise_error_if_not_found=True, usecwd=True))
     set_sqlite_llm_cache()
-    Bot.from_env()
+    run_bot()


### PR DESCRIPTION
This pull request refactors the bot initialization process by removing the `Bot` class and replacing it with standalone functions. The changes simplify the structure and improve readability.

### Refactoring of Bot Initialization:

* Removed the `Bot` class and its methods, including `__init__`, `from_env`, and `show_chat_id`. (`bot/bot.py`)
* Converted `show_chat_id`, `summarize_url`, and `translate_jp` methods into standalone asynchronous functions. (`bot/bot.py`) [[1]](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L78-R48) [[2]](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L109-R80) [[3]](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7R92-R108)
* Introduced a new `run_bot` function to handle bot initialization and command handler setup. (`bot/bot.py`)

### CLI Adjustments:

* Updated the `main` function in `bot/cli.py` to call `run_bot` instead of `Bot.from_env`. (`bot/cli.py`)