### PR TITLE
translate en and tc

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -77,18 +77,21 @@ async def summarize_url(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text(summarized)
 
 
-async def translate_jp(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
-    logger.info(update)
+def create_translate_callback(lang: str) -> callable:
+    async def translate_lang(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
+        logger.info(update)
 
-    if not update.message or not update.message.text:
-        return
+        if not update.message or not update.message.text:
+            return
 
-    raw_text = get_full_message_text(update)
+        raw_text = get_full_message_text(update)
 
-    translated = translate(raw_text, lang="日文")
-    logger.info("Replying to chat ID: {} with: {}", update.message.chat_id, translated)
+        translated = translate(raw_text, lang=lang)
+        logger.info("Replying to chat ID: {} with: {}", update.message.chat_id, translated)
 
-    await update.message.reply_text(translated)
+        await update.message.reply_text(translated)
+
+    return translate_lang
 
 
 def run_bot() -> None:
@@ -103,6 +106,8 @@ def run_bot() -> None:
 
     app = Application.builder().token(token).build()
     app.add_handler(CommandHandler("sum", summarize_url, filters=filters.Chat(chat_ids)))
-    app.add_handler(CommandHandler("jp", translate_jp, filters=filters.Chat(chat_ids)))
+    app.add_handler(CommandHandler("jp", create_translate_callback("日文"), filters=filters.Chat(chat_ids)))
+    app.add_handler(CommandHandler("tc", create_translate_callback("繁體中文"), filters=filters.Chat(chat_ids)))
+    app.add_handler(CommandHandler("en", create_translate_callback("英文"), filters=filters.Chat(chat_ids)))
     app.add_handler(CommandHandler("chat_id", show_chat_id))
     app.run_polling(allowed_updates=Update.ALL_TYPES)

--- a/bot/translate.py
+++ b/bot/translate.py
@@ -7,12 +7,7 @@ from langchain_core.runnables import RunnableSerializable
 from .utils import ai_message_repr
 from .utils import get_llm_from_env
 
-PROMPT_TEMPLATE = """翻譯文本為{lang}，並提供簡潔的文法和用法說明，搭配範例句子以增強理解。
-
-文本：
-{text}
-
-翻譯："""  # noqa
+PROMPT_TEMPLATE = """翻譯以下文字為{lang}：{text}"""
 
 
 @functools.cache
@@ -23,7 +18,7 @@ def get_chain() -> RunnableSerializable:
     return chain
 
 
-def translate(text: str, lang: str = "日文") -> str:
+def translate(text: str, lang: str) -> str:
     chain = get_chain()
     ai_message: AIMessage = chain.invoke({"text": text, "lang": lang})
     return ai_message_repr(ai_message)


### PR DESCRIPTION
This pull request introduces enhancements to the translation functionality of the bot, making it more flexible and adding support for multiple languages. The most important changes include creating a callback function for translations, updating command handlers to support new languages, and simplifying the translation prompt template.

Enhancements to translation functionality:

* [`bot/bot.py`](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L80-R95): Replaced the `translate_jp` function with a more flexible `create_translate_callback` function that can handle multiple languages.
* [`bot/bot.py`](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L106-R111): Updated the `run_bot` function to add command handlers for Japanese, Traditional Chinese, and English translations using the new `create_translate_callback` function.

Simplification of translation prompt:

* [`bot/translate.py`](diffhunk://#diff-b31ab3d80598171f607f0558d4140cf8ffd9c983b912b92c21b883bb751cd359L10-R10): Simplified the `PROMPT_TEMPLATE` to a more concise format.

General code improvements:

* [`bot/translate.py`](diffhunk://#diff-b31ab3d80598171f607f0558d4140cf8ffd9c983b912b92c21b883bb751cd359L26-R21): Modified the `translate` function to accept a language parameter, removing the default value.