### PR TITLE
remove context log

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -32,9 +32,8 @@ def get_message_text(update: Update) -> str:
     return f"{reply_text}\n{message_text}" if reply_text else message_text
 
 
-async def log_message_(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def log_message_(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     logger.info("Message Update: {}", update)
-    logger.info("Message Context: {}", context)
 
 
 async def echo_message_(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
This pull request includes a minor change to the `log_message_` function in the `bot/bot.py` file. The change removes the logging of the `context` parameter.

* [`bot/bot.py`](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L35-L37): Removed logging of the `context` parameter in the `log_message_` function.