### PR TITLE
add ptt cookie

### DIFF
--- a/bot/utils.py
+++ b/bot/utils.py
@@ -14,6 +14,7 @@ from langchain_core.messages import AIMessage
 DEFAULT_HEADERS = {
     "Accept-Language": "zh-TW,zh;q=0.9,ja;q=0.8,en-US;q=0.7,en;q=0.6",
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36",  # noqa
+    "Cookie": "over18=1",  # ptt
 }
 
 


### PR DESCRIPTION
This pull request includes a small change to the `bot/utils.py` file. The change adds a new header to the `DEFAULT_HEADERS` dictionary to include a `Cookie` value indicating the user is over 18.

* [`bot/utils.py`](diffhunk://#diff-dd45f3df183d56681fe535b88682614d873aa4583f66868e34736c251d3c28a9R17): Added a `Cookie` header with the value `over18=1` to the `DEFAULT_HEADERS` dictionary.