### PR TITLE
send error message to telegraph

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,6 +19,7 @@ from .polish import polish
 from .summarize import summarize
 from .translate import translate
 from .translate import translate_and_explain
+from .utils import create_page
 from .utils import load_document
 from .utils import parse_url
 from .yahoo_finance import query_tickers
@@ -140,23 +141,24 @@ async def help_callback(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 async def error_callback(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
     logger.error("Exception while handling an update: {}", context.error)
 
-    # update_str = update.to_dict() if isinstance(update, Update) else str(update)
+    update_str = update.to_dict() if isinstance(update, Update) else str(update)
 
-    message = (
+    html_content = (
         "An exception was raised while handling an update\n"
-        # f"<pre>update = {html.escape(json.dumps(update_str, indent=2, ensure_ascii=False))}</pre>\n\n"
-        # f"<pre>context.chat_data = {html.escape(str(context.chat_data))}</pre>\n\n"
-        # f"<pre>context.user_data = {html.escape(str(context.user_data))}</pre>\n\n"
+        f"<pre>update = {html.escape(json.dumps(update_str, indent=2, ensure_ascii=False))}</pre>\n\n"
+        f"<pre>context.chat_data = {html.escape(str(context.chat_data))}</pre>\n\n"
+        f"<pre>context.user_data = {html.escape(str(context.user_data))}</pre>\n\n"
         f"<pre>context.error = {html.escape(str(context.error))}</pre>\n\n"
     )
     if context.error:
         tb_list = traceback.format_exception(None, context.error, context.error.__traceback__)
         tb_string = "".join(tb_list)
-        message += f"<pre>Traceback (most recent call last):\n{html.escape(tb_string)}</pre>"
+        html_content += f"<pre>Traceback (most recent call last):\n{html.escape(tb_string)}</pre>"
 
+    page_url = create_page(title="Error", html_content=html_content)
     developer_chat_id = os.getenv("DEVELOPER_CHAT_ID", None)
     if developer_chat_id:
-        await context.bot.send_message(chat_id=developer_chat_id, text=message, parse_mode=ParseMode.HTML)
+        await context.bot.send_message(chat_id=developer_chat_id, text=page_url, parse_mode=ParseMode.MARKDOWN_V2)
 
     # if isinstance(update, Update) and update.message:
     #     await update.message.reply_text(text=message, parse_mode=ParseMode.HTML)

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -10,6 +10,7 @@ from urllib.parse import urlunparse
 import chardet
 import httpx
 import numpy as np
+import telegraph
 import whisper
 import yt_dlp
 from bs4 import BeautifulSoup
@@ -282,3 +283,17 @@ def load_transcribe_by_whisper(url: str) -> str:
     result = model.transcribe(audio)
     logger.info("transcribe result: {}", result)
     return str(result["text"])
+
+
+@functools.cache
+def get_telegraph_client() -> telegraph.Telegraph:
+    client = telegraph.Telegraph()
+    client.create_account(short_name="Narumi's Bot")
+    return client
+
+
+def create_page(title: str, **kwargs) -> str:
+    client = get_telegraph_client()
+
+    resp = client.create_page(title=title, **kwargs)
+    return resp["url"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -3359,6 +3359,23 @@ mpmath = ">=1.1.0,<1.4"
 dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
 
 [[package]]
+name = "telegraph"
+version = "2.2.0"
+description = "Telegraph API wrapper"
+optional = false
+python-versions = "*"
+files = [
+    {file = "telegraph-2.2.0-py3-none-any.whl", hash = "sha256:d20b2a5d7cfdd66890c8c3fd60aa8585cabb7c6b03579d3eb1cd8af056ed9971"},
+    {file = "telegraph-2.2.0.tar.gz", hash = "sha256:012908f18208c451c7189f4bda7c39a1369241ac436c7543bb6c3fccbe9cfd5d"},
+]
+
+[package.dependencies]
+requests = "*"
+
+[package.extras]
+aio = ["httpx"]
+
+[[package]]
 name = "tenacity"
 version = "8.5.0"
 description = "Retry code until it succeeds"
@@ -4027,4 +4044,4 @@ test = ["pytest (>=8.1,<9.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "c4b3e8a58dc166d3e71ebdfcadce42ef5e9893707aa4cc47fe15825dd61910c0"
+content-hash = "cfaa1a279e6597b9ef2b734e661114d573c16f40555b943ee82250e750c0e245"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ yfinance = "^0.2.43"
 openai-whisper = "^20240930"
 yt-dlp = "^2024.9.27"
 chardet = "^5.2.0"
+telegraph = "^2.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.1"


### PR DESCRIPTION
This pull request includes several changes to the `bot` module, focusing on error handling improvements and the addition of new utility functions. The most important changes involve importing new modules, updating error handling to create and send error pages, and adding new utility functions for creating Telegraph pages.

### Error Handling Improvements:
* [`bot/bot.py`](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L143-R161): Updated `error_callback` to create a Telegraph page with error details and send the page URL to the developer's chat instead of sending the error message directly.

### New Utility Functions:
* [`bot/utils.py`](diffhunk://#diff-dd45f3df183d56681fe535b88682614d873aa4583f66868e34736c251d3c28a9R286-R299): Added `create_page` function to create a Telegraph page and return its URL, and `get_telegraph_client` function to initialize a Telegraph client.

### Module Imports:
* [`bot/bot.py`](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7R22): Added import for `create_page` from `utils`.
* [`bot/utils.py`](diffhunk://#diff-dd45f3df183d56681fe535b88682614d873aa4583f66868e34736c251d3c28a9R13): Added import for `telegraph`.

### Dependency Updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R24): Added `telegraph` as a new dependency.