### PR TITLE
load singlefile html

### DIFF
--- a/bot/loaders/__init__.py
+++ b/bot/loaders/__init__.py
@@ -1,2 +1,3 @@
+from .singlefile_html import load_singlefile_html
 from .video_transcript import load_video_transcript
 from .youtube_transcript import load_youtube_transcript

--- a/bot/loaders/singlefile_html.py
+++ b/bot/loaders/singlefile_html.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+
+
+def get_singlefile_path_from_env() -> str:
+    return os.getenv("SINGLEFILE_PATH", "/Users/narumi/.local/bin/single-file")
+
+
+def singlefile_download(url: str, cookies_file: str | None = None) -> str:
+    filename = tempfile.mktemp(suffix=".html")
+
+    singlefile_path = get_singlefile_path_from_env()
+
+    cmds = [singlefile_path]
+
+    if cookies_file is not None:
+        if not Path(cookies_file).exists():
+            raise FileNotFoundError("cookies file not found")
+
+        cmds += [
+            "--browser-cookies-file",
+            cookies_file,
+        ]
+
+    cmds += [
+        "--filename-conflict-action",
+        "overwrite",
+        url,
+        filename,
+    ]
+
+    subprocess.run(cmds)
+    return filename
+
+
+def load_singlefile_html(url: str) -> str:
+    f = singlefile_download(url)
+
+    with open(f, "rb") as fp:
+        soup = BeautifulSoup(fp, "html.parser")
+        text = soup.get_text(strip=True)
+    return text


### PR DESCRIPTION
This pull request introduces a new loader for handling HTML files using the `single-file` tool and refactors existing code to utilize this new loader. The most important changes include adding the `load_singlefile_html` function, removing the old `singlefile_download` function, and updating the `load_document` function to use the new loader.

### New Loader Implementation:

* Added `load_singlefile_html` function in `bot/loaders/singlefile_html.py` to download and parse HTML files using the `single-file` tool. (`bot/loaders/singlefile_html.py`)

### Refactoring:

* Imported `load_singlefile_html` in `bot/loaders/__init__.py` to make it accessible throughout the module. (`bot/loaders/__init__.py`)
* Removed the old `singlefile_download` function from `bot/utils.py` and replaced its usage with the new `load_singlefile_html` function. (`bot/utils.py`) [[1]](diffhunk://#diff-dd45f3df183d56681fe535b88682614d873aa4583f66868e34736c251d3c28a9L3-R16) [[2]](diffhunk://#diff-dd45f3df183d56681fe535b88682614d873aa4583f66868e34736c251d3c28a9L85-L109) [[3]](diffhunk://#diff-dd45f3df183d56681fe535b88682614d873aa4583f66868e34736c251d3c28a9L155-R128)