### PR TITLE
summarize pdf file

### DIFF
--- a/bot/loaders/__init__.py
+++ b/bot/loaders/__init__.py
@@ -1,4 +1,5 @@
 from .pdf import load_pdf
+from .pdf import load_pdf_file
 from .ptt import load_ptt
 from .singlefile_html import load_singlefile_html
 from .url import load_url

--- a/bot/loaders/pdf.py
+++ b/bot/loaders/pdf.py
@@ -21,3 +21,7 @@ def load_pdf(url: str) -> str:
         fp.write(resp.content)
 
     return docs_to_str(PyPDFLoader(fp.name).load())
+
+
+def load_pdf_file(f: str) -> str:
+    return docs_to_str(PyPDFLoader(f).load())


### PR DESCRIPTION
This pull request introduces new functionality to handle PDF document summaries in the bot's summarization feature and includes some code refactoring. The most important changes include adding a new function to load PDF files, modifying the summarization callback to handle PDF documents, and updating imports accordingly.

### New functionality for PDF summaries:

* [`bot/loaders/pdf.py`](diffhunk://#diff-a2aa5f39ff1948fc2b03c57e5bf9935c227eadcc6a714589a687550e3b4655e8R24-R27): Added a new function `load_pdf_file` to load PDF files directly from the file path.
* [`bot/bot.py`](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7L49-R68): Modified the `summarize_callback` function to check if the message is a reply to a PDF document and, if so, load and summarize the PDF document.

### Code refactoring:

* [`bot/bot.py`](diffhunk://#diff-d7094880f6e1845d792ec1cb547780e39276fc2fb13321ce3b52e393fc1755a7R17): Updated imports to include the new `load_pdf_file` function.
* [`bot/loaders/__init__.py`](diffhunk://#diff-5ff4ad71da67c332d931bb17f2e315aedfdf6694f45a2ce62d0a70076a59cd62R2): Added the new `load_pdf_file` function to the module exports.