### PR TITLE
Reorder type check step in CI workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,10 +26,10 @@ jobs:
         run: uv sync
       - name: Lint
         run: uv run ruff check .
-      - name: Type check
-        run: uv run mypy --install-types --non-interactive .
       - name: Test
         run: uv run pytest -v -s --cov=src --cov-report=xml tests
+      - name: Type check
+        run: uv run mypy --install-types --non-interactive .
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/python.yml` file. The change reorders the steps in the `jobs:` section to place the type check after the lint step.

* [`.github/workflows/python.yml`](diffhunk://#diff-092659a9bd0068791326fb1d08f005532e5aeb983b999a7bd32c51deee0a71d5L29-R32): Reordered the type check step to follow the lint step.