### PR TITLE
FIX: move mlx-whisper to extra dep

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install uv
         run: pip install uv
       - name: Install dependencies
-        run: uv tool install --reinstall --force --python=${{ matrix.python-version }} .
+        run: uv tool install --reinstall --force --python=${{ matrix.python-version }} --with mlx .
       - name: Create dotenv
         run: |
           echo BOT_TOKEN=${{ secrets.BOT_TOKEN }} >> .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "charset-normalizer>=3.4.0",
     "twse>=0.1.1",
     "youtube-search>=2.1.2",
+    "openai-whisper>=20240930",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,6 @@ dependencies = [
     "charset-normalizer>=3.4.0",
     "twse>=0.1.1",
     "youtube-search>=2.1.2",
-    "mlx-whisper>=0.4.1",
-    "numba>=0.60.0",
 ]
 
 [build-system]
@@ -45,6 +43,12 @@ dev-dependencies = [
 
 [project.scripts]
 bot = "bot.cli:main"
+
+[project.optional-dependencies]
+mlx = [
+    "mlx-whisper>=0.4.1",
+    "numba>=0.60.0",
+]
 
 [tool.ruff]
 exclude = ["build"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "twse>=0.1.1",
     "youtube-search>=2.1.2",
     "openai-whisper>=20240930",
+    "numba>=0.60.0",
 ]
 
 [build-system]
@@ -48,7 +49,6 @@ bot = "bot.cli:main"
 [project.optional-dependencies]
 mlx = [
     "mlx-whisper>=0.4.1",
-    "numba>=0.60.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,7 @@ dependencies = [
     { name = "loguru" },
     { name = "lxml" },
     { name = "markdownify" },
+    { name = "numba" },
     { name = "openai" },
     { name = "openai-whisper" },
     { name = "pypdf" },
@@ -66,7 +67,6 @@ dependencies = [
 [package.optional-dependencies]
 mlx = [
     { name = "mlx-whisper" },
-    { name = "numba" },
 ]
 
 [package.dev-dependencies]
@@ -91,7 +91,7 @@ requires-dist = [
     { name = "lxml", specifier = ">=5.3.0" },
     { name = "markdownify", specifier = ">=0.13.1" },
     { name = "mlx-whisper", marker = "extra == 'mlx'", specifier = ">=0.4.1" },
-    { name = "numba", marker = "extra == 'mlx'", specifier = ">=0.60.0" },
+    { name = "numba", specifier = ">=0.60.0" },
     { name = "openai", specifier = ">=1.52.0" },
     { name = "openai-whisper", specifier = ">=20240930" },
     { name = "pypdf", specifier = ">=5.0.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,7 @@ dependencies = [
     { name = "lxml" },
     { name = "markdownify" },
     { name = "openai" },
+    { name = "openai-whisper" },
     { name = "pypdf" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
@@ -92,6 +93,7 @@ requires-dist = [
     { name = "mlx-whisper", marker = "extra == 'mlx'", specifier = ">=0.4.1" },
     { name = "numba", marker = "extra == 'mlx'", specifier = ">=0.60.0" },
     { name = "openai", specifier = ">=1.52.0" },
+    { name = "openai-whisper", specifier = ">=20240930" },
     { name = "pypdf", specifier = ">=5.0.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-telegram-bot", specifier = ">=21.6" },
@@ -916,6 +918,21 @@ sdist = { url = "https://files.pythonhosted.org/packages/83/fc/77552f9ddd40ac32f
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/6f/b32b84d031c7f31b3f32c95c2a9b5ca441b254131a6c982a3dac73d3fffd/openai-1.53.0-py3-none-any.whl", hash = "sha256:20f408c32fc5cb66e60c6882c994cdca580a5648e10045cd840734194f033418", size = 387077 },
 ]
+
+[[package]]
+name = "openai-whisper"
+version = "20240930"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "tiktoken" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'linux2'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/77/952ca71515f81919bd8a6a4a3f89a27b09e73880cebf90957eda8f2f8545/openai-whisper-20240930.tar.gz", hash = "sha256:b7178e9c1615576807a300024f4daa6353f7e1a815dac5e38c33f1ef055dd2d2", size = 800544 }
 
 [[package]]
 name = "packaging"

--- a/uv.lock
+++ b/uv.lock
@@ -50,8 +50,6 @@ dependencies = [
     { name = "loguru" },
     { name = "lxml" },
     { name = "markdownify" },
-    { name = "mlx-whisper" },
-    { name = "numba" },
     { name = "openai" },
     { name = "pypdf" },
     { name = "python-dotenv" },
@@ -62,6 +60,12 @@ dependencies = [
     { name = "youtube-search" },
     { name = "youtube-transcript-api" },
     { name = "yt-dlp" },
+]
+
+[package.optional-dependencies]
+mlx = [
+    { name = "mlx-whisper" },
+    { name = "numba" },
 ]
 
 [package.dev-dependencies]
@@ -85,8 +89,8 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "lxml", specifier = ">=5.3.0" },
     { name = "markdownify", specifier = ">=0.13.1" },
-    { name = "mlx-whisper", specifier = ">=0.4.1" },
-    { name = "numba", specifier = ">=0.60.0" },
+    { name = "mlx-whisper", marker = "extra == 'mlx'", specifier = ">=0.4.1" },
+    { name = "numba", marker = "extra == 'mlx'", specifier = ">=0.60.0" },
     { name = "openai", specifier = ">=1.52.0" },
     { name = "pypdf", specifier = ">=5.0.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },


### PR DESCRIPTION
This pull request includes several changes to improve dependency management and enhance the video transcription functionality. The main changes involve updating dependencies, modifying the workflow configuration, and enhancing the video transcription loader to support both `mlx_whisper` and `openai-whisper`.

### Dependency Management:
* Updated `pyproject.toml` to replace `mlx-whisper` with `openai-whisper` in the main dependencies and added `mlx-whisper` as an optional dependency under `[project.optional-dependencies]`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L25-R25) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R49-R53)

### Workflow Configuration:
* Modified the `.github/workflows/deploy.yml` file to include the `--with mlx` flag during the installation of dependencies.

### Video Transcription Enhancements:
* Updated `src/bot/loaders/video_transcript.py` to conditionally import `mlx_whisper` and check if it is installed.
* Refactored the `load_video_transcript` function to use a new `_transcribe` function that supports both `mlx_whisper` and `openai-whisper`.