### PR TITLE
FIX: handle yt_dlp.utils.DownloadError

### DIFF
--- a/src/bot/loaders/video_transcript.py
+++ b/src/bot/loaders/video_transcript.py
@@ -6,6 +6,7 @@ import tempfile
 import numpy as np
 import whisper
 import yt_dlp
+from loguru import logger
 
 try:
     import mlx_whisper  # noqa: F401
@@ -98,7 +99,12 @@ def _transcribe(audio: np.ndarray) -> dict:
 
 
 def load_video_transcript(url: str) -> str | None:
-    f = ytdlp_download(url)
+    try:
+        f = ytdlp_download(url)
+    except yt_dlp.utils.DownloadError as e:
+        logger.info("Unable to download video from URL: {}, got error: {}", url, e)
+        return None
+
     audio = load_audio(f)
     result = _transcribe(audio)
     return result.get("text", "")


### PR DESCRIPTION
This pull request includes changes to the `src/bot/loaders/video_transcript.py` file to enhance logging and error handling when downloading video transcripts. The most important changes include adding a logger and handling download errors.

Logging and error handling improvements:

* [`src/bot/loaders/video_transcript.py`](diffhunk://#diff-d66391e7f97d6a7e9b393cb28f077fc48d8a65898263a8384eff08deb72bbd67R9): Added `loguru` logger import to enable logging functionality.
* [`src/bot/loaders/video_transcript.py`](diffhunk://#diff-d66391e7f97d6a7e9b393cb28f077fc48d8a65898263a8384eff08deb72bbd67R102-R107): Modified the `load_video_transcript` function to include a try-except block for handling `yt_dlp.utils.DownloadError` and logging the error message when a video download fails.