### PR TITLE
[codex] Add message source logging

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,3 +12,4 @@
 2026-03-30 | docs(readme): clarify model access section as required for LLM features (#internal)
 2026-03-31 | refactor(clean): remove dead code, redundant checks, fix imports and __all__ exports (#internal)
 2026-04-09 | refactor(utils): switch text chunking to RecursiveChunker (#internal)
+2026-04-23 | chore(utils): add message-source logging for reply context resolution (#internal)

--- a/src/bot/callbacks/utils.py
+++ b/src/bot/callbacks/utils.py
@@ -71,26 +71,46 @@ def get_message_text(
     include_reply_to_message: bool = True,
     include_user_name: bool = False,
 ) -> str:
-    message_text = getattr(message, "text", None) or getattr(message, "caption", None) or ""
-    message_text = strip_command(message_text)
+    raw_message_text = getattr(message, "text", None) or getattr(message, "caption", None) or ""
+    message_text = strip_command(raw_message_text)
+    current_message_found = bool(message_text)
 
     if include_user_name:
         name = get_user_display_name(message)
         if name:
             message_text = f"{name}: {message_text}"
 
-    if include_reply_to_message:
-        reply_to_message = getattr(message, "reply_to_message", None)
-        if reply_to_message:
-            reply_to_message_text = get_message_text(
-                reply_to_message,
-                include_reply_to_message=False,
-                include_user_name=include_user_name,
-            )
-            if reply_to_message_text:
-                message_text = f"{reply_to_message_text}\n\n{message_text}"
+    reply_to_message = getattr(message, "reply_to_message", None)
+    reply_message_found = False
 
-    logger.info("Message text: %s", message_text)
+    if include_reply_to_message and reply_to_message:
+        reply_to_message_text = get_message_text(
+            reply_to_message,
+            include_reply_to_message=False,
+            include_user_name=include_user_name,
+        )
+        if reply_to_message_text:
+            reply_message_found = True
+            message_text = f"{reply_to_message_text}\n\n{message_text}"
+
+    chat = getattr(message, "chat", None)
+    chat_id = getattr(chat, "id", None)
+    message_id = getattr(message, "message_id", None)
+    logger.info(
+        (
+            "Resolved message text for chat_id=%s message_id=%s: "
+            "current_message_found=%s include_reply_to_message=%s reply_target_found=%s "
+            "reply_message_found=%s final_text_length=%s"
+        ),
+        chat_id,
+        message_id,
+        current_message_found,
+        include_reply_to_message,
+        reply_to_message is not None,
+        reply_message_found,
+        len(message_text),
+    )
+    logger.debug("Resolved message text content: %s", message_text)
     return message_text
 
 


### PR DESCRIPTION
## Summary

- add structured logging in get_message_text to show whether current message text was found
- log whether a reply target exists and whether reply text was resolved
- append the changelog entry for the logging update

## Why

This makes it easier to debug whether the bot is picking up the current conversation text, the replied-to message text, or both.

## Validation

- uv run ruff check src/bot/callbacks/utils.py
- uv run pytest tests/callbacks/test_utils.py -v