### PR TITLE
[codex] Preserve reply/current text in agent URL preprocessing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,3 +12,4 @@
 2026-03-30 | docs(readme): clarify model access section as required for LLM features (#internal)
 2026-03-31 | refactor(clean): remove dead code, redundant checks, fix imports and __all__ exports (#internal)
 2026-04-09 | refactor(utils): switch text chunking to RecursiveChunker (#internal)
+2026-04-23 | fix(agent): preserve reply and current message text when appending URL content (#internal)

--- a/docs/GOTCHA.md
+++ b/docs/GOTCHA.md
@@ -11,3 +11,7 @@
 - Symptom: `ty` reports `invalid-assignment` when tests assign `AsyncMock` directly to `callback.handle_message`.
   Root cause: Bound async methods have a concrete callable type, and direct `AsyncMock` attribute assignment violates the checker's attribute type constraints.
   Prevention: In tests, patch methods with `patch.object(..., new_callable=AsyncMock)` instead of direct reassignment.
+
+- Symptom: Replying to a bot message with a URL causes the model input to lose the user's actual question or the replied context, so the agent answers only from fetched page content.
+  Root cause: URL preprocessing replaced the whole composed message with `load_url()` output instead of appending fetched content after the original reply/current text.
+  Prevention: Keep reply/current message blocks intact in the final user payload and append URL content as extra sections rather than substituting the prompt.

--- a/src/bot/agents/chat.py
+++ b/src/bot/agents/chat.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 current_time = datetime.now(ZoneInfo("Asia/Taipei"))
 
 INSTRUCTIONS = f"""
-你是 Telegram 助手。用繁體中文直接回答重點，必要時簡短補充。訊息若為 <name>(<username>): <message>，只處理 <message>。每個任務最多問一次關鍵缺漏，不重複確認；資訊足夠就直接執行並回結果。未知要明說，假設要標示；只要資訊不足，就必須先查詢再回答。
+你是 Telegram 助手。用繁體中文直接回答重點，必要時簡短補充。若輸入包含 `Replied message:` 與 `Current message:` 區塊，請把 `Replied message:` 視為上下文，優先回應 `Current message:` 的需求；若只有單一訊息，就直接處理整段內容。每個任務最多問一次關鍵缺漏，不重複確認；資訊足夠就直接執行並回結果。未知要明說，假設要標示；只要資訊不足，就必須先查詢再回答。
 """.strip()  # noqa
 
 

--- a/src/bot/callbacks/agent.py
+++ b/src/bot/callbacks/agent.py
@@ -58,6 +58,9 @@ class AgentCallback:
 
         # add the user message to the list of messages
         messages.append(cast(TResponseInputItem, {"role": "user", "content": message_text}))
+        last_user_item = messages[-1]
+        logger.debug("Final processed message_text for chat %s: %s", message.chat.id, message_text)
+        logger.debug("Last user input item for chat %s: %s", message.chat.id, last_user_item)
 
         # send the messages to the agent
         logger.info("Running agent with %s messages", len(messages))

--- a/src/bot/callbacks/utils.py
+++ b/src/bot/callbacks/utils.py
@@ -94,6 +94,28 @@ def get_message_text(
     return message_text
 
 
+def get_message_text_without_reply(message: Message, include_user_name: bool = False) -> str:
+    """Return the current message text without reply context."""
+    return get_message_text(
+        message,
+        include_reply_to_message=False,
+        include_user_name=include_user_name,
+    )
+
+
+def format_reply_context(reply_text: str, current_text: str) -> str:
+    """Format reply context with explicit labels for the model."""
+    return f"Replied message:\n{reply_text}\n\nCurrent message:\n{current_text}"
+
+
+def append_url_contents(message_text: str, url_contents: list[tuple[str, str]]) -> str:
+    """Append loaded URL content after the original message text."""
+    sections = [message_text]
+    for url, content in url_contents:
+        sections.append(f"URL content from {url}:\n{content}")
+    return "\n\n".join(sections)
+
+
 def _is_message_like(obj: Any) -> bool:
     if obj is None:
         return False
@@ -151,13 +173,22 @@ async def get_processed_message_text(
         如果成功: (text, None)
         如果失敗: (None, error_message)
     """
-    message_text = get_message_text(
-        message,
-        include_reply_to_message=include_reply_to_message,
-        include_user_name=include_user_name,
-    )
-    if not message_text:
+    current_message_text = get_message_text_without_reply(message, include_user_name=include_user_name)
+    if not current_message_text:
         return None, None
+
+    reply_message_text = ""
+    if include_reply_to_message:
+        reply_to_message = getattr(message, "reply_to_message", None)
+        if reply_to_message:
+            reply_message_text = get_message_text_without_reply(
+                reply_to_message,
+                include_user_name=include_user_name,
+            )
+
+    message_text = (
+        format_reply_context(reply_message_text, current_message_text) if reply_message_text else current_message_text
+    )
 
     urls = parse_urls(message_text)
 
@@ -182,11 +213,7 @@ async def get_processed_message_text(
         logger.warning("%s, got error: %s", error_msg, e)
         return None, error_msg
     else:
-        # 組合所有內容
-        if len(contents) == 1:
-            return contents[0], None
-        # 多個 URL 時，用分隔符組合內容
-        combined_content = "\n\n---\n\n".join(contents)
+        combined_content = append_url_contents(message_text, list(zip(urls, contents, strict=True)))
         return combined_content, None
 
 

--- a/tests/callbacks/test_agent.py
+++ b/tests/callbacks/test_agent.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 from agents import TResponseInputItem
+from aiogram.types import User
 
 from bot.callbacks.agent import AgentCallback
 
@@ -194,6 +195,93 @@ async def test_memory_trimmed_to_max_cache_size(mock_runner, mock_get_processed_
         {"role": "assistant", "content": "m2"},
         {"role": "user", "content": "m3"},
     ]
+
+
+def _build_message(
+    text: str,
+    *,
+    chat_id: int = 12345,
+    user: User | None = None,
+    reply_to_message=None,
+):
+    message = Mock()
+    message.text = text
+    message.caption = None
+    message.from_user = user or User(id=123, is_bot=False, first_name="TestUser", username="testuser")
+    message.reply_to_message = reply_to_message
+    message.chat.id = chat_id
+    message.answer = AsyncMock()
+    return message
+
+
+def _build_runner_result() -> Mock:
+    result = Mock()
+    result.new_items = []
+    result.final_output = "ok"
+    result.to_input_list.return_value = [
+        {"role": "user", "content": "stored"},
+        {"role": "assistant", "content": "ok"},
+    ]
+    return result
+
+
+@patch("bot.callbacks.utils.load_url")
+@patch("bot.callbacks.agent.Runner")
+async def test_handle_message_reply_keeps_reply_and_current_text(mock_runner, mock_load_url):
+    mock_runner.run = AsyncMock(return_value=_build_runner_result())
+    mock_load_url.return_value = "unused"
+
+    reply_message = _build_message("Previous bot answer")
+    message = _build_message("Please expand this", reply_to_message=reply_message)
+
+    callback = AgentCallback(Mock())
+    await callback.handle_message(message)
+
+    input_messages = mock_runner.run.call_args.kwargs["input"]
+    assert input_messages[-1]["content"] == (
+        "Replied message:\nTestUser(testuser): Previous bot answer\n\n"
+        "Current message:\nTestUser(testuser): Please expand this"
+    )
+
+
+@patch("bot.callbacks.utils.load_url")
+@patch("bot.callbacks.agent.Runner")
+async def test_handle_message_reply_with_current_url_keeps_current_text_in_runner_input(mock_runner, mock_load_url):
+    mock_runner.run = AsyncMock(return_value=_build_runner_result())
+    mock_load_url.return_value = "Loaded URL content"
+
+    reply_message = _build_message("Previous bot answer")
+    message = _build_message("Please summarize https://example.com", reply_to_message=reply_message)
+
+    callback = AgentCallback(Mock())
+    await callback.handle_message(message)
+
+    input_messages = mock_runner.run.call_args.kwargs["input"]
+    assert input_messages[-1]["content"] == (
+        "Replied message:\nTestUser(testuser): Previous bot answer\n\n"
+        "Current message:\nTestUser(testuser): Please summarize https://example.com\n\n"
+        "URL content from https://example.com:\nLoaded URL content"
+    )
+
+
+@patch("bot.callbacks.utils.load_url")
+@patch("bot.callbacks.agent.Runner")
+async def test_handle_message_reply_with_reply_url_does_not_drop_current_text(mock_runner, mock_load_url):
+    mock_runner.run = AsyncMock(return_value=_build_runner_result())
+    mock_load_url.return_value = "Loaded URL content"
+
+    reply_message = _build_message("See https://example.com")
+    message = _build_message("What changed?", reply_to_message=reply_message)
+
+    callback = AgentCallback(Mock())
+    await callback.handle_message(message)
+
+    input_messages = mock_runner.run.call_args.kwargs["input"]
+    assert input_messages[-1]["content"] == (
+        "Replied message:\nTestUser(testuser): See https://example.com\n\n"
+        "Current message:\nTestUser(testuser): What changed?\n\n"
+        "URL content from https://example.com:\nLoaded URL content"
+    )
 
 
 # handle_command

--- a/tests/callbacks/test_utils.py
+++ b/tests/callbacks/test_utils.py
@@ -192,7 +192,7 @@ async def test_url_loading_success(mock_parse_urls, mock_load_url, test_user: Us
     message.reply_to_message = None
 
     text, error = await get_processed_message_text(message, require_url=False)
-    assert text == "Content from URL"
+    assert text == "https://example.com\n\nURL content from https://example.com:\nContent from URL"
     assert error is None
     mock_load_url.assert_called_once_with("https://example.com")
 
@@ -229,7 +229,7 @@ async def test_require_url_with_url_success(mock_parse_urls, mock_load_url, test
     message.reply_to_message = None
 
     text, error = await get_processed_message_text(message, require_url=True)
-    assert text == "Content from URL"
+    assert text == "https://example.com\n\nURL content from https://example.com:\nContent from URL"
     assert error is None
     mock_load_url.assert_called_once_with("https://example.com")
 
@@ -248,7 +248,11 @@ async def test_multiple_urls_loading_success(mock_parse_urls, mock_load_url, tes
     message.reply_to_message = None
 
     text, error = await get_processed_message_text(message, require_url=False)
-    assert text == "Content from URL 1\n\n---\n\nContent from URL 2"
+    assert text == (
+        "Check https://example1.com and https://example2.com\n\n"
+        "URL content from https://example1.com:\nContent from URL 1\n\n"
+        "URL content from https://example2.com:\nContent from URL 2"
+    )
     assert error is None
     assert mock_load_url.call_count == 2
 
@@ -285,7 +289,12 @@ async def test_multiple_urls_require_url(mock_parse_urls, mock_load_url, test_us
     message.reply_to_message = None
 
     text, error = await get_processed_message_text(message, require_url=True)
-    assert text == "Content 1\n\n---\n\nContent 2\n\n---\n\nContent 3"
+    assert text == (
+        "Three URLs: https://example1.com https://example2.com https://example3.com\n\n"
+        "URL content from https://example1.com:\nContent 1\n\n"
+        "URL content from https://example2.com:\nContent 2\n\n"
+        "URL content from https://example3.com:\nContent 3"
+    )
     assert error is None
     assert mock_load_url.call_count == 3
 
@@ -313,9 +322,71 @@ async def test_include_reply_to_message_true_includes_reply_text(mock_parse_urls
         include_reply_to_message=True,
     )
 
-    assert text == "Original message\n\nReply message"
+    assert text == "Replied message:\nOriginal message\n\nCurrent message:\nReply message"
     assert error is None
-    mock_parse_urls.assert_called_once_with("Original message\n\nReply message")
+    mock_parse_urls.assert_called_once_with("Replied message:\nOriginal message\n\nCurrent message:\nReply message")
+
+
+@pytest.mark.asyncio
+@patch("bot.callbacks.utils.load_url")
+@patch("bot.callbacks.utils.parse_urls")
+async def test_reply_message_with_current_url_keeps_sections(
+    mock_parse_urls,
+    mock_load_url,
+    test_user: User,
+):
+    mock_parse_urls.return_value = ["https://example.com"]
+    mock_load_url.return_value = "Loaded page"
+
+    reply_message = Mock(spec=Message)
+    reply_message.text = "Bot said hello"
+    reply_message.caption = None
+    reply_message.from_user = test_user
+    reply_message.reply_to_message = None
+
+    message = Mock(spec=Message)
+    message.text = "Please summarize https://example.com"
+    message.caption = None
+    message.from_user = test_user
+    message.reply_to_message = reply_message
+
+    text, error = await get_processed_message_text(message, require_url=False, include_reply_to_message=True)
+
+    assert text == (
+        "Replied message:\nBot said hello\n\n"
+        "Current message:\nPlease summarize https://example.com\n\n"
+        "URL content from https://example.com:\nLoaded page"
+    )
+    assert error is None
+
+
+@pytest.mark.asyncio
+@patch("bot.callbacks.utils.load_url")
+@patch("bot.callbacks.utils.parse_urls")
+async def test_reply_message_with_reply_url_keeps_original_sections(mock_parse_urls, mock_load_url, test_user: User):
+    mock_parse_urls.return_value = ["https://example.com"]
+    mock_load_url.return_value = "Loaded page"
+
+    reply_message = Mock(spec=Message)
+    reply_message.text = "Context https://example.com"
+    reply_message.caption = None
+    reply_message.from_user = test_user
+    reply_message.reply_to_message = None
+
+    message = Mock(spec=Message)
+    message.text = "What does this mean?"
+    message.caption = None
+    message.from_user = test_user
+    message.reply_to_message = reply_message
+
+    text, error = await get_processed_message_text(message, require_url=False, include_reply_to_message=True)
+
+    assert text == (
+        "Replied message:\nContext https://example.com\n\n"
+        "Current message:\nWhat does this mean?\n\n"
+        "URL content from https://example.com:\nLoaded page"
+    )
+    assert error is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve replied and current message text in agent preprocessing instead of replacing the whole prompt with fetched URL content
- switch reply formatting to explicit Replied message and Current message blocks and align chat-agent instructions with that structure
- add debug logging plus callback-level tests that assert the exact final Runner.run input payload

## Root cause
When a message contained a URL, get_processed_message_text() replaced the composed message with load_url() output. In reply flows this could erase both the replied bot context and the user's actual question before the model saw it.

## Impact
The agent now always receives the current user message, and reply context is retained even when either the reply or the current message contains URLs.

## Validation
- uv run pytest -v tests/callbacks/test_utils.py tests/callbacks/test_agent.py
- uv run ruff check src/bot/callbacks/utils.py src/bot/callbacks/agent.py src/bot/agents/chat.py tests/callbacks/test_utils.py tests/callbacks/test_agent.py
- uv run ty check src/bot/callbacks/utils.py src/bot/callbacks/agent.py src/bot/agents/chat.py tests/callbacks/test_utils.py tests/callbacks/test_agent.py
