### PR TITLE
refactor(callbacks): remove non-aiogram callback plumbing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,3 +21,6 @@
 2026-05-11 | chore(deps): upgrade kabigon to 0.19.3 (#internal)
 2026-05-12 | chore(deploy): warm up MCP npx packages before start
 2026-06-21 | feat(agent): disable reply handling by default (#internal)
+2026-06-23 | docs(plan): add aiogram message callback cleanup plan (#internal)
+2026-06-23 | refactor(callbacks): remove non-aiogram callback plumbing (#internal)
+2026-06-23 | fix(callbacks): preserve safe callback errors with keyword messages (#454)

--- a/docs/GOTCHA.md
+++ b/docs/GOTCHA.md
@@ -27,3 +27,7 @@
 - Symptom: Sending a bare command (e.g. `/f`) as a reply to a URL-only message silently does nothing.
   Root cause: `get_processed_message_text` early-exited with `(None, None)` when `current_message_text` was empty (command stripped), before ever reading `reply_to_message`.
   Prevention: Gather both current and reply texts before the empty-guard; only return early when both are empty.
+
+- Symptom: A `@safe_callback` aiogram handler logs and re-raises errors but does not send the user-facing error reply.
+  Root cause: aiogram dependency injection may call handlers with `message=...` as a keyword argument, so scanning only positional args misses the `Message`.
+  Prevention: Error wrappers around aiogram handlers must check both positional args and the `message` keyword for `aiogram.types.Message`.

--- a/docs/plans/archived/2026-06-23_aiogram-message-callbacks-plan.md
+++ b/docs/plans/archived/2026-06-23_aiogram-message-callbacks-plan.md
@@ -1,0 +1,34 @@
+## Goal
+
+Remove non-aiogram callback compatibility plumbing so command and file handlers accept `aiogram.types.Message` directly, with the same user-visible behavior and passing callback tests.
+
+## Context
+
+`src/bot/callbacks/utils.py` recognized `Update`, `context.args`, and `reply_text`-style objects even though the bot registers aiogram message handlers. The helper was used by ticker, file, and agent callbacks, so deleting it required updating those call sites together.
+
+## Non-Goals
+
+- Do not redesign callback routing or error reporting.
+- Do not change command output, URL loading behavior, or article generation behavior.
+
+## Plan
+
+- [x] Replace `get_message_from_update` in `src/bot/callbacks/agent.py` by changing `handle_command` and `handle_reply` to accept `Message` directly; verified with `rg -n "get_message_from_update|Update" src/bot/callbacks/agent.py` returning no matches and `uv run pytest -v -s tests/callbacks/test_agent.py` passing.
+- [x] Simplify `src/bot/callbacks/ticker.py` so `query_ticker_callback(message: Message)` parses symbols only from `message.text`; verified with updated `tests/callbacks/test_ticker.py` and `uv run pytest -v -s tests/callbacks/test_ticker.py` passing.
+- [x] Simplify `src/bot/callbacks/file_notes.py` so `file_callback(message: Message, bot: Bot)` uses aiogram dependency injection and no `_get_bot`/`context`; verified with `tests/callbacks/test_file_notes.py` passing.
+- [x] Delete cross-framework helpers from `src/bot/callbacks/utils.py`: `get_message_from_update`, `reply_text` recognition, and `Update` imports; kept `safe_callback` only smart enough to find an aiogram `Message` in direct or bound-method args; verified with `uv run pytest -v -s tests/callbacks/test_utils.py` passing.
+- [x] Sweep imports and tests for stale compatibility references; verified with `rg -n "get_message_from_update|context\.args|reply_text|Message \| Update|Update" src tests` returning no matches.
+- [x] Run quality gates for the touched surface; verified with `uv run ruff check src tests`, `uv run ty check src`, `prek run -a`, and `uv run pytest -v -s tests/callbacks/test_agent.py tests/callbacks/test_ticker.py tests/callbacks/test_utils.py tests/callbacks/test_file_notes.py tests/test_bot.py` passing.
+- [x] Append a changelog line for the implemented cleanup in `docs/CHANGELOG.md`; verified with `tail -1 docs/CHANGELOG.md` returning `2026-06-23 | refactor(callbacks): remove non-aiogram callback plumbing (#internal)`.
+
+## Risks
+
+- `file_callback(message: Message, bot: Bot)` depends on aiogram DI injecting `Bot`; mitigated by `functools.wraps` preserving the unwrapped signature and `tests/callbacks/test_file_notes.py` verifying direct `Message`/`Bot` invocation.
+- `safe_callback` decorates bound methods; mitigated by scanning positional args for `Message` and preserving agent bound-method tests.
+
+## Completion Checklist
+
+- [x] All aiogram callbacks touched by this plan expose `Message`-first signatures only, verified by `rg -n "Message \| Update|context\.args|get_message_from_update|reply_text" src/bot/callbacks` returning no matches.
+- [x] Existing ticker, agent, utility, file-note, and bot tests pass with updated direct-`Message` test setup, verified by `uv run pytest -v -s tests/callbacks/test_agent.py tests/callbacks/test_ticker.py tests/callbacks/test_utils.py tests/callbacks/test_file_notes.py tests/test_bot.py`.
+- [x] Static checks pass, verified by `uv run ruff check src tests`, `uv run ty check src`, and `prek run -a`.
+- [x] `docs/CHANGELOG.md` contains one implementation changelog line for this cleanup, verified by `tail -1 docs/CHANGELOG.md`.

--- a/src/bot/callbacks/agent.py
+++ b/src/bot/callbacks/agent.py
@@ -8,9 +8,7 @@ from agents import Runner
 from agents import TResponseInputItem
 from agents import trace
 from aiogram.types import Message
-from aiogram.types import Update
 
-from bot.callbacks.utils import get_message_from_update
 from bot.callbacks.utils import get_processed_message_text
 from bot.callbacks.utils import safe_callback
 from bot.core.message_response import MessageResponse
@@ -84,21 +82,13 @@ class AgentCallback:
         logger.debug("Saved %s messages to memory for chat key: %s", len(input_items), memory_key)
 
     @safe_callback
-    async def handle_command(self, update: Message | Update, context: object | None = None) -> None:
-        message = get_message_from_update(update)
-        if not message:
-            return
-
+    async def handle_command(self, message: Message) -> None:
         with trace("handle_command"):
             await self.handle_message(message)
 
     @safe_callback
-    async def handle_reply(self, update: Message | Update, context: object | None = None) -> None:
+    async def handle_reply(self, message: Message) -> None:
         if not self.reply_enabled:
-            return
-
-        message = get_message_from_update(update)
-        if not message:
             return
 
         # Check if this is a reply to this bot's own message

--- a/src/bot/callbacks/file_notes.py
+++ b/src/bot/callbacks/file_notes.py
@@ -10,21 +10,11 @@ from typing import cast
 from aiogram import Bot
 from aiogram.types import Document
 from aiogram.types import Message
-from aiogram.types import Update
 from kabigon.loaders.pdf import read_pdf_content
 from kabigon.loaders.utils import read_html_content
 
 from bot.agents.writer import write_article
-from bot.callbacks.utils import get_message_from_update
 from bot.callbacks.utils import safe_callback
-
-
-def _get_bot(context: object | None) -> Bot | None:
-    if isinstance(context, Bot):
-        return context
-    if context is None:
-        return None
-    return getattr(context, "bot", None)
 
 
 async def _download_document(bot: Bot, document: Document) -> Path | None:
@@ -49,15 +39,7 @@ def _read_document(file_path: Path) -> str | None:
 
 
 @safe_callback
-async def file_callback(update: Message | Update, context: object | None = None) -> None:
-    message = get_message_from_update(update)
-    if not message:
-        return
-
-    bot = _get_bot(context)
-    if bot is None:
-        return
-
+async def file_callback(message: Message, bot: Bot) -> None:
     document = message.document
     if not document:
         return

--- a/src/bot/callbacks/ticker.py
+++ b/src/bot/callbacks/ticker.py
@@ -5,10 +5,8 @@ import logging
 
 from aiogram.enums import ParseMode
 from aiogram.types import Message
-from aiogram.types import Update
 from twse.stock_info import get_stock_info
 
-from bot.callbacks.utils import get_message_from_update
 from bot.callbacks.utils import safe_callback
 from bot.callbacks.utils import strip_command
 from bot.yahoo_finance import query_tickers
@@ -16,11 +14,7 @@ from bot.yahoo_finance import query_tickers
 logger = logging.getLogger(__name__)
 
 
-def _get_symbols(message: Message, context: object | None) -> list[str]:
-    context_args = getattr(context, "args", None)
-    if context_args:
-        return list(context_args)
-
+def _get_symbols(message: Message) -> list[str]:
     text = strip_command(message.text or "")
     if not text:
         return []
@@ -58,12 +52,8 @@ def _combine_results(yf_result: str, twse_results: list[str]) -> str:
 
 
 @safe_callback
-async def query_ticker_callback(update: Message | Update, context: object | None = None) -> None:
-    message = get_message_from_update(update)
-    if not message:
-        return
-
-    symbols = _get_symbols(message, context)
+async def query_ticker_callback(message: Message) -> None:
+    symbols = _get_symbols(message)
     if not symbols:
         return
 

--- a/src/bot/callbacks/utils.py
+++ b/src/bot/callbacks/utils.py
@@ -2,10 +2,8 @@ import asyncio
 import logging
 import re
 from functools import wraps
-from typing import Any
 
 from aiogram.types import Message
-from aiogram.types import Update
 
 from bot.utils import load_url
 
@@ -103,9 +101,9 @@ def get_message_text_without_reply(message: Message, include_user_name: bool = F
     )
 
 
-def format_reply_context(reply_text: str, current_text: str) -> str:
+def format_reply_context(reply_content: str, current_text: str) -> str:
     """Format reply context with explicit labels for the model."""
-    return f"Replied message:\n{reply_text}\n\nCurrent message:\n{current_text}"
+    return f"Replied message:\n{reply_content}\n\nCurrent message:\n{current_text}"
 
 
 def _get_reply_message_text(message: Message, include_reply: bool, include_user_name: bool) -> str:
@@ -133,22 +131,14 @@ def append_url_contents(message_text: str, url_contents: list[tuple[str, str]]) 
     return "\n\n".join(sections)
 
 
-def _is_message_like(obj: Any) -> bool:
-    if obj is None:
-        return False
-    if hasattr(obj, "message") and not isinstance(obj, Message):
-        return False
-    return isinstance(obj, Message) or hasattr(obj, "answer") or hasattr(obj, "reply_text")
+def _extract_message(args: tuple[object, ...], kwargs: dict[str, object]) -> Message | None:
+    message = kwargs.get("message")
+    if isinstance(message, Message):
+        return message
 
-
-def _extract_message(args: tuple[Any, ...]) -> Message | None:
     for arg in args:
-        if _is_message_like(arg):
+        if isinstance(arg, Message):
             return arg
-    for arg in args:
-        message = getattr(arg, "message", None)
-        if _is_message_like(message):
-            return message
     return None
 
 
@@ -254,7 +244,7 @@ def safe_callback(callback_func):
 
     @wraps(callback_func)
     async def wrapper(*args, **kwargs):
-        message = _extract_message(args)
+        message = _extract_message(args, kwargs)
 
         try:
             return await callback_func(*args, **kwargs)
@@ -283,16 +273,3 @@ def safe_callback(callback_func):
             raise
 
     return wrapper
-
-
-def get_message_from_update(update_or_message: Message | Update | None) -> Message | None:
-    if update_or_message is None:
-        return None
-    message = getattr(update_or_message, "message", None)
-    if message is not None and (
-        isinstance(message, Message) or hasattr(message, "answer") or hasattr(message, "reply_text")
-    ):
-        return message
-    if isinstance(update_or_message, Message):
-        return update_or_message
-    return None

--- a/tests/callbacks/test_agent.py
+++ b/tests/callbacks/test_agent.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 from agents import TResponseInputItem
+from aiogram.types import Message
 from aiogram.types import User
 
 from bot.callbacks.agent import AgentCallback
@@ -295,27 +296,13 @@ async def test_handle_message_reply_with_reply_url_does_not_drop_current_text(mo
 @patch("bot.callbacks.agent.trace")
 async def test_handle_command(mock_trace):
     mock_agent = Mock()
-
-    mock_update = Mock()
-    mock_update.message = Mock()
+    mock_message = Mock(spec=Message)
 
     callback = AgentCallback(mock_agent)
     with patch.object(callback, "handle_message", new_callable=AsyncMock) as mock_handle_message:
-        await callback.handle_command(mock_update, None)
-    mock_handle_message.assert_called_once_with(mock_update.message)
+        await callback.handle_command(mock_message)
+    mock_handle_message.assert_called_once_with(mock_message)
     mock_trace.assert_called_once_with("handle_command")
-
-
-async def test_handle_command_no_message():
-    mock_agent = Mock()
-
-    mock_update = Mock()
-    mock_update.message = None
-
-    callback = AgentCallback(mock_agent)
-    with patch.object(callback, "handle_message", new_callable=AsyncMock) as mock_handle_message:
-        await callback.handle_command(mock_update, None)
-    mock_handle_message.assert_not_called()
 
 
 # handle_reply
@@ -330,16 +317,13 @@ async def test_handle_reply_disabled_by_default():
     mock_reply_message = Mock()
     mock_reply_message.from_user = mock_bot_user
 
-    mock_message = Mock()
+    mock_message = Mock(spec=Message)
     mock_message.reply_to_message = mock_reply_message
     mock_message.bot.id = 42
 
-    mock_update = Mock()
-    mock_update.message = mock_message
-
     callback = AgentCallback(mock_agent)
     with patch.object(callback, "handle_message", new_callable=AsyncMock) as mock_handle_message:
-        await callback.handle_reply(mock_update, None)
+        await callback.handle_reply(mock_message)
     mock_handle_message.assert_not_called()
 
 
@@ -354,16 +338,13 @@ async def test_handle_reply_valid_reply_to_this_bot(mock_trace):
     mock_reply_message = Mock()
     mock_reply_message.from_user = mock_bot_user
 
-    mock_message = Mock()
+    mock_message = Mock(spec=Message)
     mock_message.reply_to_message = mock_reply_message
     mock_message.bot.id = 42
 
-    mock_update = Mock()
-    mock_update.message = mock_message
-
     callback = AgentCallback(mock_agent, reply_enabled=True)
     with patch.object(callback, "handle_message", new_callable=AsyncMock) as mock_handle_message:
-        await callback.handle_reply(mock_update, None)
+        await callback.handle_reply(mock_message)
     mock_handle_message.assert_called_once_with(mock_message)
     mock_trace.assert_called_once_with("handle_reply")
 
@@ -378,16 +359,13 @@ async def test_handle_reply_to_other_bot_is_ignored():
     mock_reply_message = Mock()
     mock_reply_message.from_user = mock_other_bot_user
 
-    mock_message = Mock()
+    mock_message = Mock(spec=Message)
     mock_message.reply_to_message = mock_reply_message
     mock_message.bot.id = 42
 
-    mock_update = Mock()
-    mock_update.message = mock_message
-
     callback = AgentCallback(mock_agent, reply_enabled=True)
     with patch.object(callback, "handle_message", new_callable=AsyncMock) as mock_handle_message:
-        await callback.handle_reply(mock_update, None)
+        await callback.handle_reply(mock_message)
     mock_handle_message.assert_not_called()
 
 
@@ -401,29 +379,23 @@ async def test_handle_reply_not_bot_reply():
     mock_reply_message = Mock()
     mock_reply_message.from_user = mock_human_user
 
-    mock_message = Mock()
+    mock_message = Mock(spec=Message)
     mock_message.reply_to_message = mock_reply_message
     mock_message.bot.id = 42
 
-    mock_update = Mock()
-    mock_update.message = mock_message
-
     callback = AgentCallback(mock_agent, reply_enabled=True)
     with patch.object(callback, "handle_message", new_callable=AsyncMock) as mock_handle_message:
-        await callback.handle_reply(mock_update, None)
+        await callback.handle_reply(mock_message)
     mock_handle_message.assert_not_called()
 
 
 async def test_handle_reply_no_reply_message():
     mock_agent = Mock()
 
-    mock_message = Mock()
+    mock_message = Mock(spec=Message)
     mock_message.reply_to_message = None
-
-    mock_update = Mock()
-    mock_update.message = mock_message
 
     callback = AgentCallback(mock_agent, reply_enabled=True)
     with patch.object(callback, "handle_message", new_callable=AsyncMock) as mock_handle_message:
-        await callback.handle_reply(mock_update, None)
+        await callback.handle_reply(mock_message)
     mock_handle_message.assert_not_called()

--- a/tests/callbacks/test_file_notes.py
+++ b/tests/callbacks/test_file_notes.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+from aiogram import Bot
+from aiogram.types import Document
+from aiogram.types import Message
+
+from bot.callbacks.file_notes import file_callback
+
+
+@pytest.mark.asyncio
+@patch("bot.callbacks.file_notes.write_article", new_callable=AsyncMock)
+@patch("bot.callbacks.file_notes.read_pdf_content")
+async def test_file_callback_reads_pdf_with_injected_bot(mock_read_pdf_content, mock_write_article, tmp_path):
+    file_path = tmp_path / "note.pdf"
+    file_path.write_text("pdf bytes")
+    mock_read_pdf_content.return_value = "pdf text"
+
+    article = Mock()
+    article.reply = AsyncMock()
+    mock_write_article.return_value = article
+
+    file = Mock()
+    file.download_to_drive = AsyncMock(return_value=file_path)
+
+    bot = Mock(spec=Bot)
+    bot.get_file = AsyncMock(return_value=file)
+
+    document = Mock(spec=Document)
+    document.file_id = "file-id"
+
+    message = Mock(spec=Message)
+    message.document = document
+
+    await file_callback(message, bot)
+
+    bot.get_file.assert_awaited_once_with("file-id")
+    mock_read_pdf_content.assert_called_once_with(file_path)
+    mock_write_article.assert_awaited_once_with("pdf text")
+    article.reply.assert_awaited_once_with(message)
+    assert not file_path.exists()

--- a/tests/callbacks/test_ticker.py
+++ b/tests/callbacks/test_ticker.py
@@ -1,4 +1,5 @@
 import json
+from typing import cast
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -6,7 +7,6 @@ from unittest.mock import patch
 import pytest
 from aiogram.enums import ParseMode
 from aiogram.types import Message
-from aiogram.types import Update
 from aiogram.types import User
 
 from bot.callbacks.ticker import query_ticker_callback
@@ -17,29 +17,20 @@ def test_user() -> User:
     return User(id=123, is_bot=False, first_name="TestUser", username="testuser")
 
 
-@pytest.mark.asyncio
-async def test_query_ticker_callback_no_message():
-    update = Mock(spec=Update)
-    update.message = None
-    context = Mock()
-
-    result = await query_ticker_callback(update, context)
-    assert result is None
+def _message(text: str, test_user: User) -> tuple[Message, AsyncMock]:
+    message = Mock(spec=Message)
+    message.text = text
+    message.from_user = test_user
+    answer = AsyncMock()
+    message.answer = answer
+    return cast(Message, message), answer
 
 
 @pytest.mark.asyncio
 async def test_query_ticker_callback_no_args(test_user: User):
-    message = Mock(spec=Message)
-    message.text = "/ticker"
-    message.from_user = test_user
+    message, _answer = _message("/ticker", test_user)
 
-    update = Mock(spec=Update)
-    update.message = message
-
-    context = Mock()
-    context.args = []
-
-    result = await query_ticker_callback(update, context)
+    result = await query_ticker_callback(message)
     assert result is None
 
 
@@ -53,24 +44,15 @@ async def test_query_ticker_callback_success(mock_get_stock_info, mock_query_tic
     mock_stock_info.pretty_repr.return_value = "TWSE result for AAPL"
     mock_get_stock_info.return_value = mock_stock_info
 
-    message = Mock(spec=Message)
-    message.text = "/ticker AAPL"
-    message.from_user = test_user
-    message.answer = AsyncMock()
+    message, answer = _message("/ticker AAPL", test_user)
 
-    update = Mock(spec=Update)
-    update.message = message
-
-    context = Mock()
-    context.args = ["AAPL"]
-
-    await query_ticker_callback(update, context)
+    await query_ticker_callback(message)
 
     mock_query_tickers.assert_called_once_with(["AAPL"])
     mock_get_stock_info.assert_called_once_with("AAPL")
 
     expected_result = "Yahoo Finance result for AAPL\n\nTWSE result for AAPL"
-    message.answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
+    answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
 
 
 @pytest.mark.asyncio
@@ -83,24 +65,15 @@ async def test_query_ticker_callback_yahoo_finance_error(mock_get_stock_info, mo
     mock_stock_info.pretty_repr.return_value = "TWSE result for AAPL"
     mock_get_stock_info.return_value = mock_stock_info
 
-    message = Mock(spec=Message)
-    message.text = "/ticker AAPL"
-    message.from_user = test_user
-    message.answer = AsyncMock()
+    message, answer = _message("/ticker AAPL", test_user)
 
-    update = Mock(spec=Update)
-    update.message = message
-
-    context = Mock()
-    context.args = ["AAPL"]
-
-    await query_ticker_callback(update, context)
+    await query_ticker_callback(message)
 
     mock_query_tickers.assert_called_once_with(["AAPL"])
     mock_get_stock_info.assert_called_once_with("AAPL")
 
     expected_result = "TWSE result for AAPL"
-    message.answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
+    answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
 
 
 @pytest.mark.asyncio
@@ -110,24 +83,15 @@ async def test_query_ticker_callback_twse_error(mock_get_stock_info, mock_query_
     mock_query_tickers.return_value = "Yahoo Finance result for AAPL"
     mock_get_stock_info.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
 
-    message = Mock(spec=Message)
-    message.text = "/ticker AAPL"
-    message.from_user = test_user
-    message.answer = AsyncMock()
+    message, answer = _message("/ticker AAPL", test_user)
 
-    update = Mock(spec=Update)
-    update.message = message
-
-    context = Mock()
-    context.args = ["AAPL"]
-
-    await query_ticker_callback(update, context)
+    await query_ticker_callback(message)
 
     mock_query_tickers.assert_called_once_with(["AAPL"])
     mock_get_stock_info.assert_called_once_with("AAPL")
 
     expected_result = "Yahoo Finance result for AAPL"
-    message.answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
+    answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
 
 
 @pytest.mark.asyncio
@@ -143,24 +107,15 @@ async def test_query_ticker_callback_multiple_symbols(mock_get_stock_info, mock_
 
     mock_get_stock_info.side_effect = [mock_stock_info1, mock_stock_info2]
 
-    message = Mock(spec=Message)
-    message.text = "/ticker AAPL GOOGL"
-    message.from_user = test_user
-    message.answer = AsyncMock()
+    message, answer = _message("/ticker AAPL GOOGL", test_user)
 
-    update = Mock(spec=Update)
-    update.message = message
-
-    context = Mock()
-    context.args = ["AAPL", "GOOGL"]
-
-    await query_ticker_callback(update, context)
+    await query_ticker_callback(message)
 
     mock_query_tickers.assert_called_once_with(["AAPL", "GOOGL"])
     assert mock_get_stock_info.call_count == 2
 
     expected_result = "Yahoo Finance results\n\nTWSE result for AAPL\n\nTWSE result for GOOGL"
-    message.answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
+    answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
 
 
 @pytest.mark.asyncio
@@ -170,21 +125,12 @@ async def test_query_ticker_callback_no_results(mock_get_stock_info, mock_query_
     mock_query_tickers.side_effect = Exception("No data")
     mock_get_stock_info.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
 
-    message = Mock(spec=Message)
-    message.text = "/ticker INVALID"
-    message.from_user = test_user
-    message.answer = AsyncMock()
+    message, answer = _message("/ticker INVALID", test_user)
 
-    update = Mock(spec=Update)
-    update.message = message
-
-    context = Mock()
-    context.args = ["INVALID"]
-
-    result = await query_ticker_callback(update, context)
+    result = await query_ticker_callback(message)
 
     assert result is None
-    message.answer.assert_called_once()
-    call_args = message.answer.call_args[0][0]
+    answer.assert_called_once()
+    call_args = answer.call_args[0][0]
     assert "無法查詢到股票代碼" in call_args
     assert "INVALID" in call_args

--- a/tests/callbacks/test_utils.py
+++ b/tests/callbacks/test_utils.py
@@ -328,7 +328,7 @@ async def test_multiple_urls_require_url(mock_parse_urls, mock_load_url, test_us
 
 @pytest.mark.asyncio
 @patch("bot.callbacks.utils.parse_urls")
-async def test_include_reply_to_message_true_includes_reply_text(mock_parse_urls, test_user: User):
+async def test_include_reply_to_message_true_includes_reply_content(mock_parse_urls, test_user: User):
     mock_parse_urls.return_value = []
 
     reply_message = Mock(spec=Message)
@@ -418,7 +418,7 @@ async def test_reply_message_with_reply_url_keeps_original_sections(mock_parse_u
 
 @pytest.mark.asyncio
 @patch("bot.callbacks.utils.parse_urls")
-async def test_include_reply_to_message_false_excludes_reply_text(mock_parse_urls, test_user: User):
+async def test_include_reply_to_message_false_excludes_reply_content(mock_parse_urls, test_user: User):
     mock_parse_urls.return_value = []
 
     reply_message = Mock(spec=Message)
@@ -472,6 +472,21 @@ async def test_safe_callback_exception_handling():
     call_args = mock_message.answer.call_args[0][0]
     assert "抱歉" in call_args
     assert "錯誤" in call_args
+
+
+@pytest.mark.asyncio
+async def test_safe_callback_exception_handling_with_keyword_message():
+    mock_message = Mock(spec=Message)
+    mock_message.answer = AsyncMock()
+
+    @safe_callback
+    async def test_callback(message):
+        raise ValueError("Test error")
+
+    with pytest.raises(ValueError):
+        await test_callback(message=mock_message)
+
+    mock_message.answer.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove `Update`/`context.args` compatibility from aiogram callbacks
- simplify safe callback message extraction to direct `Message` args
- add direct file callback coverage for aiogram-injected `Bot`
- archive the completed cleanup plan

## Testing
- `uv run ruff check src tests`
- `uv run ty check src`
- `prek run -a`
- `uv run pytest -v -s tests` (81 passed)
