### PR TITLE
Fix TWSE ticker Markdown escaping

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -5,6 +5,7 @@
 - `Message.answer(...)` 只會送到同一個 chat；要明確回覆到觸發訊息時，改用 `Message.reply(...)` 或帶 `reply_parameters` 的送法。
 - 共享 response model 從 `answer()` 改成 `reply()` 時，要同步更新所有 callbacks 與測試的 awaited mocks，不然很容易出現 `'Mock' object can't be awaited`。
 - callback 測試若會走到 `logfire.span(...)`，要在 `tests/conftest.py` 先設 `LOGFIRE_IGNORE_NO_CONFIG=1`，不然 pytest 會噴未設定 warning。
+- TWSE 的 `pretty_repr()` 不會跳脫股票名稱內的 MarkdownV2 字元（例如 `國巨*`）；送 Telegram 前要先跳脫外部文字欄位，否則會出現 `can't parse entities`。
 
 ## TASTE
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,3 +24,4 @@
 2026-06-23 | docs(plan): add aiogram message callback cleanup plan (#internal)
 2026-06-23 | refactor(callbacks): remove non-aiogram callback plumbing (#internal)
 2026-06-23 | fix(callbacks): preserve safe callback errors with keyword messages (#454)
+2026-07-20 | fix(ticker): escape TWSE stock names for Telegram MarkdownV2 (#internal)

--- a/src/bot/callbacks/ticker.py
+++ b/src/bot/callbacks/ticker.py
@@ -5,10 +5,12 @@ import logging
 
 from aiogram.enums import ParseMode
 from aiogram.types import Message
+from twse.stock_info import StockInfoResponse
 from twse.stock_info import get_stock_info
 
 from bot.callbacks.utils import safe_callback
 from bot.callbacks.utils import strip_command
+from bot.yahoo_finance import escape_markdown
 from bot.yahoo_finance import query_tickers
 
 logger = logging.getLogger(__name__)
@@ -30,6 +32,21 @@ def _query_yahoo(symbols: list[str]) -> str:
         return ""
 
 
+def _format_twse_result(result: StockInfoResponse) -> str:
+    formatted_stocks = []
+    for stock in result.msg_array:
+        if not stock.exists():
+            continue
+        escaped_stock = stock.model_copy(
+            update={
+                "name": escape_markdown(stock.name or ""),
+                "symbol": escape_markdown(stock.symbol or ""),
+            }
+        )
+        formatted_stocks.append(escaped_stock.pretty_repr())
+    return "\n\n".join(formatted_stocks)
+
+
 async def _query_twse(symbols: list[str]) -> list[str]:
     results = []
     for symbol in symbols:
@@ -38,8 +55,9 @@ async def _query_twse(symbols: list[str]) -> list[str]:
         except json.JSONDecodeError as e:
             logger.warning("Failed to query TWSE for %s: %s", symbol, e)
             continue
-        if result.msg_array:
-            results.append(result.pretty_repr())
+        formatted_result = _format_twse_result(result)
+        if formatted_result:
+            results.append(formatted_result)
     return results
 
 

--- a/src/bot/yahoo_finance.py
+++ b/src/bot/yahoo_finance.py
@@ -1,8 +1,8 @@
 import logging
-import re
 from typing import Any
 
 import yfinance as yf
+from aiogram.utils.text_decorations import markdown_decoration
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +56,7 @@ def escape_markdown(text: str) -> str:
     Returns:
         Escaped text string, or empty string if input is None
     """
-    # Convert to string first
-    pattern = r"([_*\[\]()~`>#+=|{}.!-])"
-    return re.sub(pattern, r"\\\1", text)
+    return markdown_decoration.quote(text)
 
 
 def format_value(value: float) -> str:

--- a/tests/callbacks/test_ticker.py
+++ b/tests/callbacks/test_ticker.py
@@ -8,7 +8,9 @@ import pytest
 from aiogram.enums import ParseMode
 from aiogram.types import Message
 from aiogram.types import User
+from twse.stock_info import StockInfo
 
+from bot.callbacks.ticker import _query_twse
 from bot.callbacks.ticker import query_ticker_callback
 
 
@@ -26,6 +28,13 @@ def _message(text: str, test_user: User) -> tuple[Message, AsyncMock]:
     return cast(Message, message), answer
 
 
+def _stock_response(symbol: str, name: str) -> tuple[Mock, str]:
+    stock = StockInfo.model_validate(
+        {"c": symbol, "n": name, "o": 100, "h": 110, "l": 90, "z": 105, "y": 100, "v": 1000, "ex": "tse"}
+    )
+    return Mock(msg_array=[stock]), stock.pretty_repr()
+
+
 @pytest.mark.asyncio
 async def test_query_ticker_callback_no_args(test_user: User):
     message, _answer = _message("/ticker", test_user)
@@ -35,13 +44,26 @@ async def test_query_ticker_callback_no_args(test_user: User):
 
 
 @pytest.mark.asyncio
+@patch("bot.callbacks.ticker.get_stock_info")
+async def test_query_twse_escapes_markdown_in_stock_name(mock_get_stock_info):
+    stock = StockInfo.model_validate(
+        {"c": "2327", "n": "國巨*", "o": 663, "h": 666, "l": 630, "z": 630, "y": 699, "v": 30727, "ex": "tse"}
+    )
+    response = Mock(msg_array=[stock])
+    mock_get_stock_info.return_value = response
+
+    result = await _query_twse(["2327"])
+
+    assert result[0].startswith("📊 *國巨\\* \\(2327\\)*")
+
+
+@pytest.mark.asyncio
 @patch("bot.callbacks.ticker.query_tickers")
 @patch("bot.callbacks.ticker.get_stock_info")
 async def test_query_ticker_callback_success(mock_get_stock_info, mock_query_tickers, test_user: User):
     mock_query_tickers.return_value = "Yahoo Finance result for AAPL"
 
-    mock_stock_info = Mock()
-    mock_stock_info.pretty_repr.return_value = "TWSE result for AAPL"
+    mock_stock_info, twse_result = _stock_response("AAPL", "AAPL Taiwan")
     mock_get_stock_info.return_value = mock_stock_info
 
     message, answer = _message("/ticker AAPL", test_user)
@@ -51,7 +73,7 @@ async def test_query_ticker_callback_success(mock_get_stock_info, mock_query_tic
     mock_query_tickers.assert_called_once_with(["AAPL"])
     mock_get_stock_info.assert_called_once_with("AAPL")
 
-    expected_result = "Yahoo Finance result for AAPL\n\nTWSE result for AAPL"
+    expected_result = f"Yahoo Finance result for AAPL\n\n{twse_result}"
     answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
 
 
@@ -61,8 +83,7 @@ async def test_query_ticker_callback_success(mock_get_stock_info, mock_query_tic
 async def test_query_ticker_callback_yahoo_finance_error(mock_get_stock_info, mock_query_tickers, test_user: User):
     mock_query_tickers.side_effect = Exception("Yahoo Finance API error")
 
-    mock_stock_info = Mock()
-    mock_stock_info.pretty_repr.return_value = "TWSE result for AAPL"
+    mock_stock_info, twse_result = _stock_response("AAPL", "AAPL Taiwan")
     mock_get_stock_info.return_value = mock_stock_info
 
     message, answer = _message("/ticker AAPL", test_user)
@@ -72,7 +93,7 @@ async def test_query_ticker_callback_yahoo_finance_error(mock_get_stock_info, mo
     mock_query_tickers.assert_called_once_with(["AAPL"])
     mock_get_stock_info.assert_called_once_with("AAPL")
 
-    expected_result = "TWSE result for AAPL"
+    expected_result = twse_result
     answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
 
 
@@ -100,10 +121,8 @@ async def test_query_ticker_callback_twse_error(mock_get_stock_info, mock_query_
 async def test_query_ticker_callback_multiple_symbols(mock_get_stock_info, mock_query_tickers, test_user: User):
     mock_query_tickers.return_value = "Yahoo Finance results"
 
-    mock_stock_info1 = Mock()
-    mock_stock_info1.pretty_repr.return_value = "TWSE result for AAPL"
-    mock_stock_info2 = Mock()
-    mock_stock_info2.pretty_repr.return_value = "TWSE result for GOOGL"
+    mock_stock_info1, twse_result1 = _stock_response("AAPL", "AAPL Taiwan")
+    mock_stock_info2, twse_result2 = _stock_response("GOOGL", "GOOGL Taiwan")
 
     mock_get_stock_info.side_effect = [mock_stock_info1, mock_stock_info2]
 
@@ -114,7 +133,7 @@ async def test_query_ticker_callback_multiple_symbols(mock_get_stock_info, mock_
     mock_query_tickers.assert_called_once_with(["AAPL", "GOOGL"])
     assert mock_get_stock_info.call_count == 2
 
-    expected_result = "Yahoo Finance results\n\nTWSE result for AAPL\n\nTWSE result for GOOGL"
+    expected_result = f"Yahoo Finance results\n\n{twse_result1}\n\n{twse_result2}"
     answer.assert_called_once_with(expected_result, parse_mode=ParseMode.MARKDOWN_V2)
 
 


### PR DESCRIPTION
## Summary

- escape TWSE stock names and symbols before formatting Telegram MarkdownV2
- use aiogram's MarkdownV2 quoting for ticker output
- add regression coverage for stock names containing Markdown characters

## Testing

- `uv run pytest -v -s tests`
- `uv run ruff check src tests`
- `uv run ty check src tests`
- `prek run -a`
